### PR TITLE
Fix broken Markdown syntax for the acorn link

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,4 +10,6 @@ npm install
 npm run build
 ```
 
-Then load the `build/` folder as an [unpacked extension](https://developer.chrome.com/extensions/getstarted#manifest) in Chrome. From the Wordpress editor page for a story, you should be able to click the squirrel in your Chrome navigation bar to download a Markdown file. (TODO: the squirrel doesn't work well as an icon; it should be changed to [the acorn](https:/)/projects.seattletimes.com/2018/how-to-buy-a-home/assets/aside-graphics/acorn.png)
+Then load the `build/` folder as an [unpacked extension](https://developer.chrome.com/extensions/getstarted#manifest) in Chrome. From the Wordpress editor page for a story, you should be able to click the squirrel in your Chrome navigation bar to download a Markdown file. (TODO: the squirrel doesn't work well as an icon; it should be changed to [the acorn](https://projects.seattletimes.com/2018/how-to-buy-a-home/assets/aside-graphics/acorn.png). 
+
+![the acorn is bluish with a white ribbon bow affixed to its cap](https://projects.seattletimes.com/2018/how-to-buy-a-home/assets/aside-graphics/acorn.png)


### PR DESCRIPTION
## Changes

- fixes the Markdown syntax for the acorn link
- adds the acorn as an image in the README with alt text.

<img width="918" alt="screen shot 2018-07-24 at 8 56 46 pm" src="https://user-images.githubusercontent.com/1754187/43173675-1f50d99a-8f84-11e8-8d8c-f6943661f2a9.png">

## Why

Because I saw this repo in a [newsnerdrepos tweet](https://twitter.com/newsnerdrepos/status/1021910430862721024), clicked on the repo, saw the broken readme, and decided to fix it. Cheers! 🥂 